### PR TITLE
Compile firmware with gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+
+RUN sudo apt-get -q update && sudo apt-get install -yq gcc-arm-none-eabi && sudo rm -rf /var/lib/apt/lists/*
+
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - command: git clone --recurse-submodules https://github.com/jamesturton/shelly-dimmer-stm32.git && cd shelly-dimmer-stm32 && make -C libopencm3 && make -C src
+image:
+  file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
 tasks:
-  - command: git clone --recurse-submodules https://github.com/jamesturton/shelly-dimmer-stm32.git && cd shelly-dimmer-stm32 && make -C libopencm3 && make -C src
+  - command: make -C libopencm3 && make -C src
 image:
   file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See the [releases](https://github.com/jamesturton/shelly-dimmer-stm32/releases) 
 
 # Instructions
 
-Super easy way hit [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://github.com/jamesturton/shelly-dimmer-stm32) and you did it.
+Super easy way hit [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/jamesturton/shelly-dimmer-stm32) and you did it.
 
 for building local on your PC do:
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ To flash the firmware directly to the STM32 chip using a programmer such as the 
 
  5. ```make -C src flash BMP_PORT=/dev/ttyBmpGdb```
 
- To convert the binary firmware file to a header file for use in Tasmota firmware use the ```binary-parser``` utility in tthe ```scripts``` directory:
-
- 6. ```gcc scripts/binary-parser.c -o scripts/binary-parser```
- 7. ```chmod +x scripts/binary-parser```
- 8. ```scripts/binary-parser src/shelly-dimmer-stm32.bin shelly-dimmer-stm32.h 50 1```
-
 # Pinout
 Here is a guess of the pinout of the *STM32F031K6* chip.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ An open-source firmware for the STM32 co-processor on the Shelly Dimmer.
 See the [releases](https://github.com/jamesturton/shelly-dimmer-stm32/releases) page to download the latest pre-build binary.
 
 # Instructions
+
+Super easy way hit [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://github.com/jamesturton/shelly-dimmer-stm32) and you did it.
+
+for building local on your PC do:
+
  1. ```git clone --recurse-submodules https://github.com/jamesturton/shelly-dimmer-stm32.git```
  2. ```cd shelly-dimmer-stm32```
  3. ```make -C libopencm3 # (Only needed once)```


### PR DESCRIPTION
just by hitting Gitpod-Ready-to-Code Badge.
Removed the not needed conversion to a header file in readme