### PR TITLE
improved led dimming

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -105,6 +105,8 @@ static hw_types hw_version                  = dimmer2;
 static uint16_t brightness                  = 0;
 static uint16_t brightness_req              = 0;
 static uint32_t brightness_adj              = 0;
+static uint32_t low_brightness_threshold    = 300; // switch on the mosfets later for low brightness
+
 static bool     leading_edge                = false;
 
 static uint16_t adc_data[ADC_NUM_CHANNELS]  = {0};
@@ -222,6 +224,7 @@ static void packet_process(uint8_t *buf)
         case SHD_SETTINGS_CMD:
             {
                 leading_edge = 2 - buf[pos + 2];
+                low_brightness_threshold = buf[pos + 7] << 8 | buf[pos + 6]; // this is warmup_brightness
             }
             break;
         default:
@@ -591,6 +594,7 @@ static void timer1_setup(void)
     timer_set_period(TIM1, 65535);
 
     timer_enable_irq(TIM1, TIM_DIER_CC1IE);
+    timer_enable_irq(TIM1, TIM_DIER_CC2IE);
 
     // Finally enable timer 1
     timer_enable_counter(TIM1);
@@ -727,6 +731,37 @@ static void adc_setup(void)
     adc_start_conversion_regular(ADC1);
 }
 
+static void mosfet_on(void) {
+    // Turn on the MOSFETs
+    if(leading_edge != (bool)(hw_version == dimmer1))
+    {
+        gpio_set(GPIOA, GPIO8);
+        gpio_set(GPIOA, GPIO11);
+        gpio_set(GPIOA, GPIO12);
+    }
+    else
+    {
+        gpio_clear(GPIOA, GPIO8);
+        gpio_clear(GPIOA, GPIO11);
+        gpio_clear(GPIOA, GPIO12);
+    }
+}
+
+static void mosfet_off(void) {
+    if(leading_edge != (bool)(hw_version == dimmer1))
+    {
+        gpio_clear(GPIOA, GPIO8);
+        gpio_clear(GPIOA, GPIO11);
+        gpio_clear(GPIOA, GPIO12);
+    }
+    else
+    {
+        gpio_set(GPIOA, GPIO8);
+        gpio_set(GPIOA, GPIO11);
+        gpio_set(GPIOA, GPIO12);
+    }
+}
+
 int main(void)
 {
     // Setup all subsystems
@@ -757,7 +792,6 @@ int main(void)
     return 0;
 }
 
-
 // Interupts
 
 void sys_tick_handler(void)
@@ -778,19 +812,18 @@ void tim1_cc_isr(void)
             return;
 
         // Turn off the MOSFETs
-        if(leading_edge != (bool)(hw_version == dimmer1))
-        {
-            gpio_clear(GPIOA, GPIO8);
-            gpio_clear(GPIOA, GPIO11);
-            gpio_clear(GPIOA, GPIO12);
-        }
-        else
-        {
-            gpio_set(GPIOA, GPIO8);
-            gpio_set(GPIOA, GPIO11);
-            gpio_set(GPIOA, GPIO12);
-        }
+        mosfet_off();
     }
+
+    if (timer_get_flag(TIM1, TIM_SR_CC2IF))
+    {
+        // Reset interupt flag
+        timer_clear_flag(TIM1, TIM_SR_CC2IF);
+        if (brightness == 0)
+            return;
+        mosfet_on();
+    }
+
 }
 
 void tim2_isr(void)
@@ -893,7 +926,24 @@ void exti2_3_isr(void)
     if (gpio_get(GPIOB, GPIO2))
         line_freq_counter = timer_get_counter(TIM1);
     else
-        line_freq = (line_freq_counter + timer_get_counter(TIM1)) / 2;
+        line_freq = line_freq - line_freq / 64 + (line_freq_counter + timer_get_counter(TIM1)) / 2;
+
+    // Change ouput polarity if needed depending on leading edge mode
+    brightness = leading_edge ? 1000 - brightness_req : brightness_req;
+
+    // Adjust the brigtness value according to the mains frequency
+    brightness_adj = brightness * line_freq / 64000;
+    if (brightness_adj < low_brightness_threshold) {
+        timer_set_oc_value(TIM1, TIM_OC1, low_brightness_threshold);
+        timer_set_oc_value(TIM1, TIM_OC2, low_brightness_threshold - brightness_adj);
+    } else if (brightness_adj > 0) {
+        timer_set_oc_value(TIM1, TIM_OC1, brightness_adj);
+        timer_set_oc_value(TIM1, TIM_OC2, 0);
+        mosfet_on();
+    }
+    timer_set_counter(TIM1, 0);
+
+    // after setting up the timer do the rest, as this may cause jitter
 
     // Update only once per full line cycle
     if (gpio_get(GPIOB, GPIO2))
@@ -907,29 +957,5 @@ void exti2_3_isr(void)
         adc_count = 0;
     }
 
-    // Change ouput polarity if needed depending on leading edge mode
-    brightness = leading_edge ? 1000 - brightness_req : brightness_req;
-
-    // Adjust the brigtness value according to the mains frequency
-    brightness_adj = brightness * line_freq / 1000;
-    timer_set_oc_value(TIM1, TIM_OC1, brightness_adj);
-    timer_set_counter(TIM1, 0);
-
-    // No need to turn on if brightness is zero
-    if (brightness == 0)
-        return;
-
-    // Turn on the MOSFETs
-    if(leading_edge != (bool)(hw_version == dimmer1))
-    {
-        gpio_set(GPIOA, GPIO8);
-        gpio_set(GPIOA, GPIO11);
-        gpio_set(GPIOA, GPIO12);
-    }
-    else
-    {   
-        gpio_clear(GPIOA, GPIO8);
-        gpio_clear(GPIOA, GPIO11);
-        gpio_clear(GPIOA, GPIO12);
-    }
 }
+


### PR DESCRIPTION
**DISCLAIMER**

This mod may drive the shelly dimmer out of spec, at it may have more switching losses as in trailing edge mode.
Do not use it with capacitive loads.

----

Hello @jamesturton, 

I had similar flickering problems like in #6. I tried the beta firmware and this gives much better results.

My hardware setup is a Shelly Dimmer 2 with LED spots https://www.amazon.de/gp/product/B08C5CMQLM
(They are based on SM2082EG constant current controller - similar to schematic on page 10 http://www.szjuquan.com/upload_files/qb_sell_/pdf/SM2082EG.pdf) 

The problem was, that on low dimming voltages, the led flickers. I inspecht the output voltage with the oscilloscope and saw, that the trailing edge is "jittering".
It seems that the stm32 is not always in sync with the line freqency. I tried different things, to improve line sync.

1. My first thought was, that other interrupts (ADC/UART) will interfere with the EXTI or TIM1 interrupt. So I compiled a minimal STM32 firmware with hard coded dimming value. Not much improvement.
2. I tried to low-pass filter the line freq, as the line freq should be stable. You can see the idea here: https://github.com/rPraml/shelly-dimmer-stm32/commit/6a49ea3cabb26923e32f785b33658e4e9e17e31e#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R929
3. I also tried to set the timer values first in the EXTI routine and then do the more expensive current and voltage calculations. (I know from different MCs that divisions take different cycles and may cause jitter) 

But all I tried, I always ended with some jitter in the output voltage. So I tried a different approach based on the follwing idea:

When dimming to 10%, why use the beginning 10% of the sine wave and not a 10% section later in the sine wave?

A normal trailing edge will always use the sine wave from the beginning. 

Example:

[5% trailing edge](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPDAuMDUpIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)
UPeak ~50v

[20 % trailing edge](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPDAuMjApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)
UPeak ~ 185v

Here we come to the next problem: The LEDs above have a forward voltage from ~200V, so they will start glow somewhere about 185V and run with full brightness if the sine wave has > 200V.
This makes them prone to flickering if the peak voltage jitters around a few volts only.

So my idea is, not to use the beginning section of the sine wave, but a section 30% - current dimming value:

Some examples:

[5%](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPjAuMjUpKih4L3BpLWZsb29yKHgvcGkpPDAuMzApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)

[10%](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPjAuMjApKih4L3BpLWZsb29yKHgvcGkpPDAuMzApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)

[20%](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPjAuMTApKih4L3BpLWZsb29yKHgvcGkpPDAuMzApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)

[30%](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPjAuMDApKih4L3BpLWZsb29yKHgvcGkpPDAuMzApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)

[40%](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPjAuMDApKih4L3BpLWZsb29yKHgvcGkpPDAuNDApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)

[80%](http://www.fooplot.com/#W3sidHlwZSI6MCwiZXEiOiJzaW4oeCkiLCJjb2xvciI6IiNFOEU4RTgifSx7InR5cGUiOjAsImVxIjoic2luKHgpKih4L3BpLWZsb29yKHgvcGkpPjAuMDApKih4L3BpLWZsb29yKHgvcGkpPDAuODApIiwiY29sb3IiOiIjRkYwMDAwIn0seyJ0eXBlIjoxMDAwfV0-)

Currently, I use the warmup_brightness value, so I can set it with the ShdWarmupBrightness command. I get better dimming results for a value between 18 and 22.

Unfortunaltely, there is still some flickering, but I wanted to share this idea with you.
Maybe you have some other ideas to improve dimming. I think, the best soluttion will be to find a way to synchronize the timer to the line frequency. Maybe the TIM1 should run with +/-100Hz and EXTI should sync it like a PLL

Cheers
Roland